### PR TITLE
detect os architecture from os.arch environment variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <!-- Dependencies -->
         <springfox.version>3.0.0</springfox.version>
         <vaadin.version>23.3.0.alpha1</vaadin.version>
+        <pi4j.version>2.2.1</pi4j.version>
     </properties>
 
     <dependencies>
@@ -98,6 +99,21 @@
 
         <!-- Pi4J -->
         <!-- This library is not available yet within Pi4J, so for now including its former version -->
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-core</artifactId>
+            <version>${pi4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-raspberrypi</artifactId>
+            <version>${pi4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-pigpio</artifactId>
+            <version>${pi4j.version}</version>
+        </dependency>
         <!--
         <dependency>
             <groupId>be.webtechie</groupId>

--- a/src/main/java/com/pi4j/raspberrypiinfoservice/configuration/ContextConfiguration.java
+++ b/src/main/java/com/pi4j/raspberrypiinfoservice/configuration/ContextConfiguration.java
@@ -1,0 +1,48 @@
+package com.pi4j.raspberrypiinfoservice.configuration;
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ContextConfiguration {
+
+    @Configuration
+    @ConditionalOnProperty(prefix = "os", name = "arch", havingValue = "armv6l")
+    static class Armv6l {
+
+        @Bean
+        Context context() {
+
+            return Pi4J.newAutoContext();
+        }
+
+    }
+
+    @Configuration
+    @ConditionalOnProperty(prefix = "os", name = "arch", havingValue = "armv7l")
+    static class Armv7l {
+
+        @Bean
+        Context context() {
+
+            return Pi4J.newAutoContext();
+        }
+
+    }
+
+    @Configuration
+    @ConditionalOnProperty(prefix = "os", name = "arch", havingValue = "aarch64")
+    static class Aarch64 {
+
+        @Bean
+        Context context() {
+
+            return Pi4J.newAutoContext();
+        }
+
+    }
+
+}

--- a/src/test/java/com/pi4j/raspberrypiinfoservice/configuration/ContextConfigurationTests.java
+++ b/src/test/java/com/pi4j/raspberrypiinfoservice/configuration/ContextConfigurationTests.java
@@ -1,0 +1,59 @@
+package com.pi4j.raspberrypiinfoservice.configuration;
+
+import com.pi4j.context.Context;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContextConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(TestConfiguration.class));
+
+    @Test
+    void whenOsArchIsNotExpected_verifyContextDoesNotExist() {
+
+        this.contextRunner
+                .withPropertyValues("os.arch=other")
+                .run(context -> assertThat(context).doesNotHaveBean(Context.class));
+    }
+
+    @Test
+    void whenOsArchIsArmv6l_verifyContextExists() {
+
+        this.contextRunner
+                .withPropertyValues("os.arch=armv6l")
+                .run(context -> assertThat(context).hasSingleBean(Context.class));
+    }
+
+    @Test
+    void whenOsArchIsArmv7l_verifyContextExists() {
+
+        this.contextRunner
+                .withPropertyValues("os.arch=armv7l")
+                .run(context -> assertThat(context).hasSingleBean(Context.class));
+    }
+
+    /*
+     * aarch64 will also match Apple M processors
+     */
+    @Test
+    void whenOsArchIsAarch64_verifyContextExists() {
+
+        this.contextRunner
+                .withPropertyValues("os.arch=aarch64")
+                .run(context -> assertThat(context).hasSingleBean(Context.class));
+    }
+
+    @Configuration
+    @Import(ContextConfiguration.class)
+    static class TestConfiguration {
+
+    }
+
+}


### PR DESCRIPTION
This is a first pass at building a true auto-configuration library and spring boot starter to register the Pi4J Context automatically.

Each architecture will be able to manage its own needed services and can be further configured by the existence of specific libraries on the classpath. If this is appropriate to detect the architecture of the host, then further work can be performed to externalize this, make it a true spring boot autoconfigure library and starter.

Some tests override `os.arch` and detect that the context has either been registered or not.